### PR TITLE
DND-222 add config var to allow bypassing of file locking for requests

### DIFF
--- a/cnp/sdk/CnpOnline.php
+++ b/cnp/sdk/CnpOnline.php
@@ -28,5 +28,5 @@ define('CURRENT_XML_VERSION', '12.37');
 define('CURRENT_SDK_VERSION', 'PHP;12.37.0');
 define('MAX_TXNS_PER_BATCH', 100000);
 define('MAX_TXNS_PER_REQUEST', 500000);
-define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout');
+define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout,useFileLocking');
 

--- a/cnp/sdk/CommManager.php
+++ b/cnp/sdk/CommManager.php
@@ -147,7 +147,11 @@ class CommManager
 
     public function findUrl()
     {
-        return $this->synchronized();
+        if ($this->useFileLocking()) {
+            return $this->synchronized();
+        }
+
+        return $this->findUrlHandler();
     }
 
 
@@ -198,5 +202,19 @@ class CommManager
     }
     public function setLastSiteSwitchTime($milliseconds){
         $this->lastSiteSwitchTime = (string)$milliseconds;
+    }
+
+    /**
+     * Determines whether or not file locking will be used when building the requestTarget array. The default is true.
+     * The only way we don't use file locking is if the config value is defined and (string) false.
+     *
+     * @return bool
+     */
+    protected function useFileLocking() {
+        if (!isset($this->configuration['useFileLocking'])) {
+            return true;
+        }
+
+        return !('false' === strtolower($this->configuration['useFileLocking']));
     }
 }

--- a/cnp/sdk/Obj2xml.php
+++ b/cnp/sdk/Obj2xml.php
@@ -334,6 +334,10 @@ class Obj2xml
                     $config['timeout'] = isset($config_array['timeout'])? $config_array['timeout']:'65';
                 } elseif ($name == 'sftp_timeout') {
                     $config['sftp_timeout'] = isset($config_array['sftp_timeout'])? $config_array['sftp_timeout']:'720';
+                } elseif ($name == 'useFileLocking') {
+                    $config['useFileLocking'] = isset($config_array['useFileLocking'])
+                        ? $config_array['useFileLocking']
+                        : 'true';
                 } else {
                     if ((!isset($config_array[$name])) and ($name != 'proxy')) {
                         throw new \InvalidArgumentException("Missing Field /$name/");


### PR DESCRIPTION
The purpose of this PR is to allow us to bypass file locking when making vantiv requests. 

Originally I was trying to just use the vantiv repo, then discovered the possibility of concurrency problems due to file locking.  I have since opened a PR with the vantiv repo directly (our fork has diverged and added shit they don't want in their repo): https://github.com/Vantiv/cnp-sdk-for-php/pull/55

So what I did here was create a 12.37.1 branch by checking out the commit that corresponds with the 12.37.1 tag in Vantiv repo: b661acd479a6e8b5fd4a0ccc89e0fca8534880e8

I then created the 12.37.1 branch from that headless state as a baseline for this PR.  I then branched FROM 12.37.1 to create this PR so we can see the difference between OUR branch and vanilla vantiv 12.37.1.